### PR TITLE
Fix smimesign stable release detection

### DIFF
--- a/automatic/smimesign/update.ps1
+++ b/automatic/smimesign/update.ps1
@@ -14,18 +14,25 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $request = [System.Net.WebRequest]::Create('https://github.com/github/smimesign/releases/latest')
-    $request.AllowAutoRedirect = $true
-    $response = $request.GetResponse()
-    $responseUri = $response.ResponseUri
+    $releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/github/smimesign/releases' -Headers @{ 'User-Agent' = 'Chocolatey-AU' }
+    $latestRelease = $releases |
+        Where-Object { !$_.draft -and $_.tag_name -match '^v?\d+(\.\d+){1,3}$' } |
+        Sort-Object { [version]($_.tag_name -replace '^v') } -Descending |
+        Select-Object -First 1
 
-    $tag = $responseUri.AbsolutePath | Split-Path -Leaf
+    if (!$latestRelease) { throw 'Could not find a stable smimesign release.' }
+
+    $tag = $latestRelease.tag_name
     $version = $tag -replace '^v?'
+    $asset32 = $latestRelease.assets | Where-Object { $_.name -eq "smimesign-windows-386-$tag.zip" } | Select-Object -First 1
+    $asset64 = $latestRelease.assets | Where-Object { $_.name -eq "smimesign-windows-amd64-$tag.zip" } | Select-Object -First 1
+
+    if (!$asset32 -or !$asset64) { throw "Could not find smimesign Windows assets for $tag." }
 
     $Latest = @{
         Version        = $version
-        URL32          = 'https://github.com/github/smimesign/releases/download/{0}/smimesign-windows-386-{0}.zip' -f $tag
-        URL64          = 'https://github.com/github/smimesign/releases/download/{0}/smimesign-windows-amd64-{0}.zip' -f $tag
+        URL32          = $asset32.browser_download_url
+        URL64          = $asset64.browser_download_url
         ChecksumType32 = 'sha256'
         ChecksumType64 = 'sha256'
     }


### PR DESCRIPTION
## Why

The `smimesign` updater used GitHub's `/releases/latest` redirect to determine the current release. For `github/smimesign`, that redirect resolves to `v0.2.0-rc1`, even though the stable `v0.2.0` release exists and is the package version currently committed.

That means forced AU runs can regress the package URLs/checksums back to release-candidate assets.

## What changed

- Query the GitHub releases API instead of following `/releases/latest`.
- Select the highest stable numeric tag, ignoring prerelease-style tags such as `v0.2.0-rc1`.
- Resolve the 32-bit and 64-bit Windows assets from the selected release metadata instead of reconstructing URLs from the redirect target.
- Fail explicitly if no stable release or expected Windows assets are found.

## Reviewer context

This was split out of #34 so the Chocolatey-AU migration PR stays focused on the module migration and validation plumbing. This PR intentionally changes only `automatic/smimesign/update.ps1`.

## Validation

- Parsed `automatic/smimesign/update.ps1` successfully with PowerShell's parser.
- Verified the release-selection logic resolves `v0.2.0` and finds both Windows ZIP assets.