### PR TITLE
Refactor AU root script config

### DIFF
--- a/.github/workflows/test-chocolatey-au.yml
+++ b/.github/workflows/test-chocolatey-au.yml
@@ -8,13 +8,17 @@ on:
       - 'copilot/**'
     paths:
       - 'setup/au_setup.ps1'
+      - 'au_config.ps1'
       - 'update_all.ps1'
+      - 'test_all.ps1'
       - 'automatic/**'
       - '.github/workflows/test-chocolatey-au.yml'
   pull_request:
     paths:
       - 'setup/au_setup.ps1'
+      - 'au_config.ps1'
       - 'update_all.ps1'
+      - 'test_all.ps1'
       - 'automatic/**'
       - '.github/workflows/test-chocolatey-au.yml'
   workflow_dispatch:

--- a/au_config.ps1
+++ b/au_config.ps1
@@ -1,0 +1,42 @@
+if (Test-Path (Join-Path $PSScriptRoot 'update_vars.ps1')) {
+    . (Join-Path $PSScriptRoot 'update_vars.ps1')
+}
+
+function New-AuReportParams {
+    param([hashtable] $Overrides = @{})
+
+    $params = @{
+        Github_UserRepo = $Env:github_user_repo
+        NoAppVeyor     = $false
+    }
+
+    foreach ($key in $Overrides.Keys) {
+        $params[$key] = $Overrides[$key]
+    }
+
+    return $params
+}
+
+function New-AuGistOptions {
+    param(
+        [string] $Id,
+        $Path,
+        [string] $Description
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Env:github_api_key)) {
+        return $null
+    }
+
+    $gist = @{
+        Id     = $Id
+        ApiKey = $Env:github_api_key
+        Path   = $Path
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description')) {
+        $gist.Description = $Description
+    }
+
+    return $gist
+}

--- a/test_all.ps1
+++ b/test_all.ps1
@@ -2,7 +2,7 @@
 
 param( [string[]] $Name, [string] $Root = "$PSScriptRoot\automatic", [switch]$ThrowOnErrors )
 
-if (Test-Path $PSScriptRoot/update_vars.ps1) { . $PSScriptRoot/update_vars.ps1 }
+. (Join-Path $PSScriptRoot 'au_config.ps1')
 $global:au_root = Resolve-Path $Root
 
 if (($Name.Length -gt 0) -and ($Name[0] -match '^random (.+)')) {
@@ -26,22 +26,16 @@ $options = [ordered]@{
     Report = @{
         Type = 'markdown'                                   #Report type: markdown or text
         Path = "$PSScriptRoot\Update-Force-Test-${n}.md"      #Path where to save the report
-        Params= @{                                          #Report parameters:
-            Github_UserRepo = $Env:github_user_repo         #  Markdown: shows user info in upper right corner
-            NoAppVeyor  = $false                            #  Markdown: do not show AppVeyor build shield
+        Params= New-AuReportParams -Overrides @{            #Report parameters:
             Title       = "Update Force Test - Group ${n}"
             UserMessage = "[Update report](https://gist.github.com/$Env:gist_id) | **USING AU NEXT VERSION**"       #  Markdown, Text: Custom user message to show
         }
     }
 }
 
-if (![string]::IsNullOrWhiteSpace($Env:github_api_key)) {
-    $options.Gist = @{
-        Id     = $Env:gist_id_test                          #Your gist id; leave empty for new private gist
-        ApiKey = $Env:github_api_key                        #Your github api key with gist scope
-        Path   = "$PSScriptRoot\Update-Force-Test-${n}.md"       #List of files to add to the gist
-        Description = "Update Force Test Report #powershell #chocolatey"
-    }
+$gistOptions = New-AuGistOptions -Id $Env:gist_id_test -Path "$PSScriptRoot\Update-Force-Test-${n}.md" -Description "Update Force Test Report #powershell #chocolatey"
+if ($gistOptions) {
+    $options.Gist = $gistOptions
 }
 
 $global:info = updateall -Name $Name -Options $Options

--- a/update_all.ps1
+++ b/update_all.ps1
@@ -3,7 +3,7 @@
 
 param([string[]] $Name, [string] $ForcedPackages, [string] $Root = "$PSScriptRoot\automatic")
 
-if (Test-Path $PSScriptRoot/update_vars.ps1) { . $PSScriptRoot/update_vars.ps1 }
+. (Join-Path $PSScriptRoot 'au_config.ps1')
 
 $runInfoPath = "$PSScriptRoot\update_info.xml"
 $runInfoSupported = $PSVersionTable.PSEdition -ne 'Core'
@@ -20,9 +20,7 @@ $Options = [ordered]@{
     Report = @{
         Type = 'markdown'                                   #Report type: markdown or text
         Path = "$PSScriptRoot\Update-AUPackages.md"         #Path where to save the report
-        Params= @{                                          #Report parameters:
-            Github_UserRepo = $Env:github_user_repo         #  Markdown: shows user info in upper right corner
-            NoAppVeyor  = $false                            #  Markdown: do not show AppVeyor build shield
+        Params= New-AuReportParams -Overrides @{            #Report parameters:
             UserMessage = "[History](#update-history)"       #  Markdown, Text: Custom user message to show
             NoIcons     = $false                            #  Markdown: don't show icon
             IconSize    = 32                                #  Markdown: icon size
@@ -37,12 +35,9 @@ $Options = [ordered]@{
     }
 }
 
-if (![string]::IsNullOrWhiteSpace($Env:github_api_key)) {
-    $Options.Gist = @{
-        Id     = $Env:gist_id                               #Your gist id; leave empty for new private gist
-        ApiKey = $Env:github_api_key                        #Your github api key with gist scope
-        Path   = "$PSScriptRoot\Update-AUPackages.md", "$PSScriptRoot\Update-History.md"       #List of files to add to the gist
-    }
+$gistOptions = New-AuGistOptions -Id $Env:gist_id -Path @("$PSScriptRoot\Update-AUPackages.md", "$PSScriptRoot\Update-History.md")
+if ($gistOptions) {
+    $Options.Gist = $gistOptions
 }
 
 $Options.Git = @{


### PR DESCRIPTION
## Summary
- Add shared `au_config.ps1` helpers for common report params and gist options
- Refactor `update_all.ps1` and `test_all.ps1` to use the shared config while retaining script-specific overrides
- Include `au_config.ps1` and `test_all.ps1` in the AU workflow path filters

## Validation
- Compared pre/post `updateall` arguments with a stubbed equivalence harness
- Ran parser checks for changed PowerShell scripts
- Compared behavior under Windows PowerShell using normalized pre-refactor baseline